### PR TITLE
Logger feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 env/
 venv/
 booyah/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,9 @@ __pycache__/
 env/
 venv/
 booyah/
+
+# logs
 logs/
+
+# OS generated files
+.DS_Store

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,10 @@
+**Logging**
+
+Check for configurations in .env file, you can change LOG_LEVEL and LOG_FILE_PATH.
+
+Usage:
+
+> from lib.logger import logger
+> ...
+> logger.debug('Debug message', debug_object1, 'other message', debug_object2, ...)
+> logger.info('Debug message', debug_object, delimiter=', ')

--- a/src/.env
+++ b/src/.env
@@ -8,3 +8,7 @@ DB_ADAPTER=postgresql
 DB_DATABASE=booyah
 DB_USERNAME=postgres
 DB_PASSWORD=
+
+# Logging
+LOG_LEVEL=DEBUG
+LOG_FILE_PATH=$root/logs/$environment.log

--- a/src/application.py
+++ b/src/application.py
@@ -1,11 +1,13 @@
-from lib.application.application_router import ApplicationRouter
-from config.routes import ApplicationRoutes
 from py_dotenv import read_dotenv
 import os
 
 dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
 read_dotenv(dotenv_path)
 print('Spinning up environment [' + os.getenv('BOOYAH_ENV') + ']')
+
+from lib.application.application_router import ApplicationRouter
+from config.routes import ApplicationRoutes
+
 
 def application(environment, start_response):
     ApplicationRoutes.load_routes()

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,4 +1,0 @@
-[DEFAULT]
-log_file_path = $root/logs/$environment.log
-log_level = DEBUG
-

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,0 +1,4 @@
+[DEFAULT]
+log_file_path = $root/logs/$environment.log
+log_level = DEBUG
+

--- a/src/config/routes.py
+++ b/src/config/routes.py
@@ -1,5 +1,6 @@
 from lib.application.application_router import ApplicationRouter
 import json
+from lib.logger import logger
 
 ROUTES_FILE = 'config/routes.json'
 
@@ -11,7 +12,7 @@ class ApplicationRoutes:
 
         for route in routes:
             self.application_router.add_route(route)
-            print('DEBUG Registering route', route)
+            logger.debug('Registering route:', route)
 
         routese_file.close()
 

--- a/src/lib/application/application_response.py
+++ b/src/lib/application/application_response.py
@@ -1,5 +1,6 @@
 import json
 from jinja2 import Environment, PackageLoader, select_autoescape
+from ..logger import logger
 
 class ApplicationResponse:
     APP_NAME = 'booyah'
@@ -47,6 +48,6 @@ class ApplicationResponse:
 
     def get_template_path(self):
         template_path = self.environment['controller_name'] + '/' + self.environment['action_name'] + '.html'
-        print(self.environment['HTTP_ACCEPT'])
-        print('DEBUG Rendering: ' + template_path + ', format: ' + self.format())
+        logger.debug("http accept:", self.environment['HTTP_ACCEPT'])
+        logger.debug("rendering:", template_path, ', format:', self.format())
         return template_path

--- a/src/lib/application/application_router.py
+++ b/src/lib/application/application_router.py
@@ -1,6 +1,7 @@
 from lib.application.application_route import ApplicationRoute
 from lib.application.application_response import ApplicationResponse
 from lib.helpers.controller_helper import get_controller_action
+from ..logger import logger
 
 class ApplicationRouter:
     def __init__(self):
@@ -22,8 +23,7 @@ class ApplicationRouter:
         return None
 
     def respond(self, environment):
-        print('-------------------------------')
-        print('DEBUG ' + environment['REQUEST_METHOD'] + ': ' + environment['PATH_INFO'])
+        logger.debug(environment['REQUEST_METHOD'] + ':', environment['PATH_INFO'])
         controller_action = self.action(environment)
 
         if controller_action:

--- a/src/lib/helpers/controller_helper.py
+++ b/src/lib/helpers/controller_helper.py
@@ -1,6 +1,7 @@
 import importlib
 import re
 from lib.helpers.application_helper import to_camel_case
+from ..logger import logger
 
 DEFAULT_CONTROLLER_NAME = 'application_controller'
 DEFAULT_ACTION_NAME = 'index'
@@ -69,5 +70,5 @@ def get_controller_action_from_string(controller_string, environment):
     environment['controller_name'] = controller_name.replace(CONTROLLER_SUFFIX, '')
     environment['action_name'] = action_name
 
-    print('DEBUG Processing: ' + controller_class.__name__ + ' => ' + action_name)
+    logger.debug('Processing:', controller_class.__name__, '=>', action_name)
     return controller_class(environment).get_action(action_name)

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -48,7 +48,6 @@ class Logger:
             config.read(CONFIG_FILE)
         
         self._log_file_path = Template(config['DEFAULT']['log_file_path']).substitute(environment=ENV, root=base_path)
-        print(self._log_file_path)
         self.log_level = log_levels.get(config['DEFAULT']['log_level'], DEFAULT_LOG_LEVEL)
 
         os.makedirs(os.path.dirname(self._log_file_path), exist_ok=True)

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -10,7 +10,7 @@ ENV = os.getenv('BOOYAH_ENV')
 class Logger:
     """
     Used to handle server logs by levels
-    You can config log_level and log_file_path in configuration file
+    You can config LOG_LEVEL and LOG_FILE_PATH in .env file
     """
 
     def find_parent_dir(self, start_directory, target_name):

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -1,0 +1,85 @@
+import configparser
+import os
+from pathlib import Path
+from string import Template
+from datetime import datetime
+
+CONFIG_FILE = 'config.ini'
+INFO = 0
+DEBUG = 1
+WARN = 2
+ERROR = 3
+FATAL = 4
+NAMES = ['INFO', 'DEBUG', 'WARN', 'ERROR', 'FATAL']
+
+ENV = 'development'
+
+class Logger:
+  """
+  Used to handle server logs by levels
+  You can config log_level and log_file_path in configuration file
+  """
+  
+  def __init__(self):
+    config = configparser.ConfigParser()
+    config['DEFAULT'] = {
+      'log_file_path': os.path.join(Path.cwd(), 'logs', '$environment.log'),
+      'log_level': DEBUG,
+      'log_format': '$datetime $levelname $message'
+    }
+    config.read(CONFIG_FILE)
+    self._log_file_path = Template(config['DEFAULT']['log_file_path']).substitute(environment=ENV)
+    self.log_level = int(config['DEFAULT']['log_level'])
+    self.log_format = config['DEFAULT']['log_format']
+  
+  def can_write(self, level):
+    """
+    Check if log level param can be written with current log level
+    """
+    if self.log_level == INFO:
+      return level in [ INFO, WARN, ERROR, FATAL ]
+    elif self.log_level == DEBUG:
+      return True
+    elif self.log_level == WARN:
+      return level in [ WARN, ERROR, FATAL ]
+    elif self.log_level == ERROR:
+      return level in [ ERROR, FATAL ]
+    elif self.log_level == FATAL:
+      return level == FATAL
+    else:
+      return False
+  
+  def format(self, content):
+    current_datetime = datetime.now()
+    return Template(self.log_format).substitute(
+      message=content,
+      datetime=current_datetime.strftime('%Y-%m-%d %H:%M:%S')
+    )
+
+  def write(self, level, content):
+    """
+    Writes a log if allowed by level
+    """
+    if not self.can_write(int(level)):
+      return
+    
+    os.makedirs(os.path.dirname(self._log_file_path), exist_ok=True)
+    formatted_log_message = self.format(content)
+    print(formatted_log_message)
+    with open(self._log_file_path, 'a+') as f:
+      f.write(formatted_log_message + "\n")
+  
+  def info(self, content):
+    self.write(INFO, content)
+
+  def debug(self, content):
+    self.write(DEBUG, content)
+
+  def warn(self, content):
+    self.write(WARN, content)
+
+  def error(self, content):
+    self.write(ERROR, content)
+
+  def fatal(self, content):
+    self.write(FATAL, content)

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -5,53 +5,75 @@ from pathlib import Path
 from string import Template
 
 CONFIG_FILE = 'config.ini'
-DEFAULT_LOG_LEVEL = 'INFO'
+DEFAULT_LOG_LEVEL = 'DEBUG'
 log_levels = {
-  'DEBUG': logging.DEBUG,
-  'INFO': logging.INFO,
-  'WARNING': logging.WARNING,
-  'ERROR': logging.ERROR,
-  'CRITICAL': logging.CRITICAL
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL
 }
 
 ENV = 'development'
 
 class Logger:
-  """
-  Used to handle server logs by levels
-  You can config log_level and log_file_path in configuration file
-  """
-  
-  def __init__(self):
-    config = configparser.ConfigParser()
-    config['DEFAULT'] = {
-      'log_file_path': os.path.join(Path.cwd(), 'logs', '$environment.log'),
-      'log_level': DEFAULT_LOG_LEVEL,
-    }
+    """
+    Used to handle server logs by levels
+    You can config log_level and log_file_path in configuration file
+    """
 
-    if not os.path.exists(CONFIG_FILE):
-      with open(CONFIG_FILE, 'w') as configfile:
-        config.write(configfile)
-    else:
-      config.read(CONFIG_FILE)
+    def find_parent_dir(self, start_directory, target_name):
+        current_directory = os.path.abspath(start_directory)
+
+        while current_directory != os.path.dirname(current_directory):
+            if os.path.basename(current_directory) == target_name:
+                return current_directory
+            current_directory = os.path.dirname(current_directory)
+        
+        return None
     
-    self._log_file_path = Template(config['DEFAULT']['log_file_path']).substitute(environment=ENV)
-    self.log_level = log_levels.get(config['DEFAULT']['log_level'], DEFAULT_LOG_LEVEL)
+    def __init__(self):
+        config = configparser.ConfigParser()
+        base_path = os.path.dirname(self.find_parent_dir(Path.cwd(), 'src'))
+        default_log_file_path = '$root/logs/$environment.log'
+        config['DEFAULT'] = {
+            'log_file_path': default_log_file_path,
+            'log_level': DEFAULT_LOG_LEVEL,
+        }
 
-    os.makedirs(os.path.dirname(self._log_file_path), exist_ok=True)
-    logging.basicConfig(filename=self._log_file_path, level=self.log_level, format="%(asctime)s - %(levelname)s - %(message)s")
-  
-  def info(self, content):
-    logging.info(content)
+        if not os.path.exists(CONFIG_FILE):
+            with open(CONFIG_FILE, 'w') as configfile:
+                config.write(configfile)
+        else:
+            config.read(CONFIG_FILE)
+        
+        self._log_file_path = Template(config['DEFAULT']['log_file_path']).substitute(environment=ENV, root=base_path)
+        print(self._log_file_path)
+        self.log_level = log_levels.get(config['DEFAULT']['log_level'], DEFAULT_LOG_LEVEL)
 
-  def debug(self, content):
-    logging.debug(content)
+        os.makedirs(os.path.dirname(self._log_file_path), exist_ok=True)
+        logging.basicConfig(
+            level=self.log_level,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[logging.FileHandler(self._log_file_path, mode='a+'),logging.StreamHandler()]
+        )
 
-  def warn(self, content):
-    logging.warning(content)
+    def format(self, args, delimiter=' '):
+        return delimiter.join([str(arg) for arg in args])
+    
+    def info(self, *args, delimiter=' '):
+        logging.info(self.format(args, delimiter))
 
-  def error(self, content):
-    logging.error(content)
+    def debug(self, *args, delimiter=' '):
+        logging.debug(self.format(args, delimiter))
 
-  def fatal(self, content):
-    logging.critical(content)
+    def warn(self, *args, delimiter=' '):
+        logging.warning(self.format(args, delimiter))
+
+    def error(self, *args, delimiter=' '):
+        logging.error(self.format(args, delimiter))
+
+    def fatal(self, *args, delimiter=' '):
+        logging.critical(self.format(args, delimiter))
+
+logger = Logger()

--- a/src/start.sh
+++ b/src/start.sh
@@ -1,0 +1,2 @@
+pip install -r requirements.txt
+gunicorn application

--- a/src/start.sh
+++ b/src/start.sh
@@ -1,2 +1,13 @@
-pip install -r requirements.txt
+if [[ "$VIRTUAL_ENV" == "" ]]
+then
+    echo "Please run under a pyenv environment"
+    exit
+fi
+
+if ! command -v pip &> /dev/null
+then
+    pip3 install -r requirements.txt
+else
+    pip install -r requirements.txt
+fi
 gunicorn application


### PR DESCRIPTION
It creates if not exists a config.ini with the configuration of log file path and log level, the default will be $root/logs/development.log and DEBUG level.
To use, will just need to import the logger instance and call the methods (info, debug, warn, error), you can pass as many args as you want. ie:
`logger.debug('as', 'many', variable, object, dict, delimiter=', ')`